### PR TITLE
bugfix:Create the Idle Registry Current User SubKey if it doesn't exist

### DIFF
--- a/ILEditor/Classes/Config.cs
+++ b/ILEditor/Classes/Config.cs
@@ -128,6 +128,12 @@ namespace ILEditor.Classes
         public static string Encode(string ValuePlain)
         {
             RegistryKey SoftwareKey = Registry.CurrentUser.OpenSubKey("Idle", true);
+
+            if( SoftwareKey == null)
+            {
+                SoftwareKey = Registry.CurrentUser.CreateSubKey("Idle");
+            }
+
             byte[] valBytes = Encoding.ASCII.GetBytes(ValuePlain);
 
             // Generate additional entropy (will be used as the Initialization vector)
@@ -151,6 +157,12 @@ namespace ILEditor.Classes
         public static string Decode(string ValueBase64)
         {
             RegistryKey SoftwareKey = Registry.CurrentUser.OpenSubKey("Idle", true);
+
+            if( SoftwareKey == null)
+            {
+                SoftwareKey = Registry.CurrentUser.CreateSubKey("Idle");
+            }
+
             byte[] entropy = SoftwareKey.GetValue("passkey") as byte[];
 
             if (entropy != null)


### PR DESCRIPTION
I was going to open an issue, but it was simple enough for me to fix.  I haven't ever had an Idle sub key in the registry so when I picked my existing connection I didn't get the new prompt that says you have to encrypt your password.  I've added createing the subkey If it doesn't exist.  Now I do get the new prompt, and everything seems to still work.